### PR TITLE
fix: always set header horizontal padding

### DIFF
--- a/core/src/main/java/com/maxkeppeker/sheets/core/views/base/FrameBase.kt
+++ b/core/src/main/java/com/maxkeppeker/sheets/core/views/base/FrameBase.kt
@@ -91,12 +91,13 @@ fun FrameBase(
 
         header?.takeUnless { deviceOrientation == LibOrientation.LANDSCAPE }?.let {
             // Display header
+            val headerPadding = BaseValues.CONTENT_DEFAULT_PADDING
             Column(modifier = Modifier.testTag(TestTags.FRAME_BASE_HEADER)) {
                 HeaderComponent(
                     header = header,
                     contentHorizontalPadding = PaddingValues(
-                        start = horizontalContentPadding.calculateStartPadding(layoutDirection),
-                        end = horizontalContentPadding.calculateEndPadding(layoutDirection),
+                        start = headerPadding.calculateStartPadding(layoutDirection),
+                        end = headerPadding.calculateEndPadding(layoutDirection),
                     )
                 )
             }


### PR DESCRIPTION
When use  with `Header.Default`, It  

When using `OptionView` or `StateView` and setting the `Header`, there is a problem when handling the header spacing, which causes the header to be too close to the left border, as shown below:

![image](https://github.com/maxkeppeler/sheets-compose-dialogs/assets/19162205/7da7e839-025d-4557-bdf9-cf0b8e8c68dc)

Related codes:
https://github.com/maxkeppeler/sheets-compose-dialogs/blob/02195faa75f0f35111f93d42fbdabab40670b51d/option/src/main/java/com/maxkeppeler/sheets/option/OptionView.kt#L74-L75
https://github.com/maxkeppeler/sheets-compose-dialogs/blob/02195faa75f0f35111f93d42fbdabab40670b51d/core/src/main/java/com/maxkeppeker/sheets/core/views/base/FrameBase.kt#L95-L100

Therefore, a fixed spacing is forced to be set for the header processing part in `FrameBase` to resolve this problem.

**Follow-up solution:** You can try to expose the content spacing setting in the header. Like the following:

```kotlin
abstract class Header {
    open val horizontalPadding: PaddingValues? = null

    /**
     * Standard implementation of a header.
     * @param icon The icon that is displayed above the title..
     * @param title The text that will be set as title.
     */
    data class Default(
        val title: String,
        val icon: IconSource? = null,
        override val horizontalPadding: PaddingValues? = null,
    ) : Header()

    /**
     * Custom implementation of a header.
     */
    data class Custom(
        override val horizontalPadding: PaddingValues? = null,
        val header: @Composable () -> Unit
    ) : Header()
}
```